### PR TITLE
JEL-783 Fix the dropdown input when the placeholder is blank

### DIFF
--- a/src/components/atoms/internal/dropdown/DropdownUI.tsx
+++ b/src/components/atoms/internal/dropdown/DropdownUI.tsx
@@ -62,6 +62,8 @@ export function DropdownUI<T>({
     ? 'jui-border-2 jui-border-error-400'
     : 'jui-border-2 jui-border-primary-100'
 
+  const inputClass = 'jui-pl-3 jui-py-2 jui-min-h-[2.5rem] jui-rounded jui-flex-1'
+
   const RightIcon = useMemo(() => {
     if (loading) {
       return IconLoader2
@@ -108,12 +110,12 @@ export function DropdownUI<T>({
 
   return (
     <div ref={wrapperRef} className="jui-w-full jui-space-y-1 jui-relative">
-      <div className={`jui-flex jui-w-full ${baseClass} ${borderClass} ${className}`}>
+      <div className={`jui-flex ${baseClass} ${borderClass} ${className}`}>
         {searchable ? (
           <input
             name={name}
             type="text"
-            className="jui-pl-3 jui-py-2 jui-text-base jui-rounded jui-w-full jui-text-ellipsis jui-overflow-hidden jui-whitespace-nowrap focus:jui-outline-0 focus-visible:jui-outline-0 placeholder:jui-text-primary-600"
+            className={`${inputClass} jui-truncate jui-text-base focus:jui-outline-0 focus-visible:jui-outline-0 placeholder:jui-text-primary-600`}
             placeholder={placeholder}
             autoComplete="off"
             value={open ? search
@@ -126,7 +128,7 @@ export function DropdownUI<T>({
           />
         ) : (
           <div
-            className={`jui-pl-3 jui-py-2 jui-rounded jui-w-full jui-text-ellipsis jui-overflow-hidden jui-whitespace-nowrap`}
+            className={`${inputClass} jui-flex jui-items-center`}
             onClick={() => {
               if (disabled) return
               setOpen(true)
@@ -134,7 +136,7 @@ export function DropdownUI<T>({
           >
             <Typography
               style="body1"
-              className={`jui-w-full jui-text-ellipsis jui-overflow-hidden jui-whitespace-nowrap ${selectedValue && !open ? 'jui-text-primary-900' : 'jui-text-primary-600'}`}
+              className={`jui-truncate ${selectedValue && !open ? 'jui-text-primary-900' : 'jui-text-primary-600'}`}
             >
               {
                 selectedValue && !open

--- a/src/showcase/AsyncDropdownInputShowcase.tsx
+++ b/src/showcase/AsyncDropdownInputShowcase.tsx
@@ -3,6 +3,7 @@ import {useState} from 'react'
 
 type Props = {
   error?: string
+  placeholder?: string
 }
 
 type Country = {
@@ -37,7 +38,7 @@ const fetchCountries = async (search: string): Promise<Country[]> => {
   )
 }
 
-export function AsyncDropdownInputShowcase({ error }: Props) {
+export function AsyncDropdownInputShowcase({ error, placeholder }: Props) {
   const [country, setCountry] = useState<Country | null>(null)
 
   return (
@@ -47,7 +48,7 @@ export function AsyncDropdownInputShowcase({ error }: Props) {
           Uncontrolled
         </div>
         <AsyncDropdownInput
-          placeholder="Type to search countries..."
+          placeholder={placeholder ?? "Type to search countries..."}
           value={null}
           onChange={() => {}}
           optionToId={c => c.id}
@@ -63,7 +64,7 @@ export function AsyncDropdownInputShowcase({ error }: Props) {
           Controlled <span className="jui-text-xs jui-font-normal">(Selected: {country?.name ?? 'None'})</span>
         </div>
         <AsyncDropdownInput
-          placeholder="Type to search countries..."
+          placeholder={placeholder ?? "Type to search countries..."}
           value={country}
           onChange={setCountry}
           optionToId={c => c.id}
@@ -79,7 +80,7 @@ export function AsyncDropdownInputShowcase({ error }: Props) {
           Disabled
         </div>
         <AsyncDropdownInput
-          placeholder="Type to search countries..."
+          placeholder={placeholder ?? "Type to search countries..."}
           value={null}
           onChange={() => {}}
           optionToId={c => c.id}
@@ -96,7 +97,7 @@ export function AsyncDropdownInputShowcase({ error }: Props) {
           Failed fetching
         </div>
         <AsyncDropdownInput
-          placeholder="Type to search countries..."
+          placeholder={placeholder ?? "Type to search countries..."}
           value={null}
           onChange={() => {}}
           optionToId={c => c.id}


### PR DESCRIPTION
Previously, when the dropdown's placeholder is blank with the search feature off, the it shrank in height.

![image](https://github.com/user-attachments/assets/98405d4e-8359-44aa-8dea-83d899f570af)

This PR is to resolve the issue.

Additionally, the showcase has been slightly updated to control the placeholder as shown:

![image](https://github.com/user-attachments/assets/c7ef024c-d11a-4690-9cd4-352d75408548)
