### PR TITLE
JEL-792 Add support for disabled state in ToggleButton component

### DIFF
--- a/src/components/atoms/ToggleButton.tsx
+++ b/src/components/atoms/ToggleButton.tsx
@@ -7,9 +7,10 @@ type Props = {
   value: boolean
   onChange: (v: boolean) => void
   size?: Size
+  disabled?: boolean
 }
 
-export function ToggleButton({ value, onChange, size = 'small' }: Props) {
+export function ToggleButton({ value, onChange, size = 'small', disabled }: Props) {
   const [checked, setChecked] = useState(value)
 
   useEffect(() => {
@@ -34,7 +35,9 @@ export function ToggleButton({ value, onChange, size = 'small' }: Props) {
     large: '1.25rem',
   }
 
-  const activeClass = checked ? 'jui-bg-success-400' : 'jui-bg-primary-200'
+  const activeClass = checked
+    ? (disabled ? 'jui-bg-success-200 jui-opacity-50' : 'jui-bg-success-400')
+    : (disabled ? 'jui-bg-primary-100 jui-opacity-50' : 'jui-bg-primary-200')
   const base = 'jui-rounded-full jui-transition-colors jui-duration-300 jui-ease-in-out jui-shadow-inner'
   const circleBase = 'jui-rounded-full jui-bg-white jui-block jui-text-success-400 jui-flex jui-items-center jui-justify-center jui-transition-transform jui-duration-300 jui-ease-in-out jui-shadow'
 

--- a/src/showcase/ToggleButtonShowcase.tsx
+++ b/src/showcase/ToggleButtonShowcase.tsx
@@ -1,7 +1,11 @@
 import { ToggleButton } from '../components/atoms/ToggleButton'
 import { useState } from 'react'
 
-export function ToggleButtonShowcase() {
+type Props = {
+  disabled?: boolean
+}
+
+export function ToggleButtonShowcase({disabled}: Props) {
   const [checked, setChecked] = useState(false)
 
   return (
@@ -11,18 +15,21 @@ export function ToggleButtonShowcase() {
           size="small"
           value={checked}
           onChange={setChecked}
+          disabled={disabled}
         />
 
         <ToggleButton
           size="medium"
           value={checked}
           onChange={setChecked}
+          disabled={disabled}
         />
 
         <ToggleButton
           size="large"
           value={checked}
           onChange={setChecked}
+          disabled={disabled}
         />
       </div>
 
@@ -31,18 +38,21 @@ export function ToggleButtonShowcase() {
           size="small"
           value={checked}
           onChange={setChecked}
+          disabled={disabled}
         />
 
         <ToggleButton
           size="medium"
           value={checked}
           onChange={setChecked}
+          disabled={disabled}
         />
 
         <ToggleButton
           size="large"
           value={checked}
           onChange={setChecked}
+          disabled={disabled}
         />
       </div>
     </div>

--- a/src/stories/atoms/ToggleButton.stories.tsx
+++ b/src/stories/atoms/ToggleButton.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ToggleButtonShowcase } from '../../showcase/ToggleButtonShowcase'
-import { fn } from '@storybook/test'
 
 const meta = {
   title: 'Atoms/Toggle Button',
@@ -12,8 +11,5 @@ export default meta
 type Story = StoryObj<typeof meta>;
 
 export const ToggleButton: Story = {
-  args: {
-    onClick: fn(),
-    label: 'Head Chef',
-  },
+  args: {},
 }


### PR DESCRIPTION
Unlike other fields, the toggle component had not supported `disabled`.
But this time, it became needed because when the following toggle is turned on or off, the app needs to make it disabled while waiting for the server response:

![image](https://github.com/user-attachments/assets/365d0ee0-f4d0-4b2c-96f2-62b86c680232)

### Update to the showcase
Previously, the options in the showcase were irrelevant to the toggle component as shown:
![image](https://github.com/user-attachments/assets/7c187118-067e-450a-aba0-b3e1013e5f7d)
