### PR TITLE
JEL-865: DropDownInput - support bottom content for options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjelly/jelly-ui",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "type": "module",
   "scripts": {
     "dev": "storybook dev -p 6006",

--- a/src/components/atoms/internal/dropdown/DropdownOptions.tsx
+++ b/src/components/atoms/internal/dropdown/DropdownOptions.tsx
@@ -11,6 +11,7 @@ type DropdownOptionsProps<T> = {
   dropdownPosition: 'bottom' | 'top'
   wrapperRef: RefObject<HTMLDivElement>
   dropdownStatusContent?: ReactNode
+  optionsBottomContent?: ReactNode
 }
 
 export function DropdownOptions<T>({
@@ -23,6 +24,7 @@ export function DropdownOptions<T>({
   dropdownPosition,
   wrapperRef,
   dropdownStatusContent,
+  optionsBottomContent,
 }: DropdownOptionsProps<T>) {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
   const optionRefs = useRef<(HTMLDivElement | null)[]>([])
@@ -88,20 +90,23 @@ export function DropdownOptions<T>({
             </Typography>
           ) : dropdownStatusContent}
         </DropdownOptionItem>
-        : options.map((option, index) => (
-          <DropdownOptionItem
-            key={optionToId(option)}
-            ref={(el) => (optionRefs.current[index] = el)}
-            className={`jui-cursor-pointer focus:jui-outline-0 focus-visible:jui-outline-0 ${focusedIndex === index ? 'jui-bg-primary-100' : ''} ${(getBorderColour(index, option))}`}
-            onClick={() => handleOptionClick(option)}
-            onMouseEnter={() => setFocusedIndex(index)}
-            tabIndex={0}
-          >
-            <Typography style="body1">
-              {optionToLabel(option)}
-            </Typography>
-          </DropdownOptionItem>
-        ))}
+        : <>
+            {options.map((option, index) => (
+            <DropdownOptionItem
+              key={optionToId(option)}
+              ref={(el) => (optionRefs.current[index] = el)}
+              className={`jui-cursor-pointer focus:jui-outline-0 focus-visible:jui-outline-0 ${focusedIndex === index ? 'jui-bg-primary-100' : ''} ${(getBorderColour(index, option))}`}
+              onClick={() => handleOptionClick(option)}
+              onMouseEnter={() => setFocusedIndex(index)}
+              tabIndex={0}
+            >
+              <Typography style="body1">
+                {optionToLabel(option)}
+              </Typography>
+            </DropdownOptionItem>
+          ))}
+          {options.length > 0 ? optionsBottomContent : null}
+        </>}
     </div>
   )
 }

--- a/src/components/atoms/internal/dropdown/DropdownUI.tsx
+++ b/src/components/atoms/internal/dropdown/DropdownUI.tsx
@@ -13,6 +13,7 @@ type Props<T> = BaseDropdownProps<T> & {
   handleSearchChange: (search: string) => void
   options: T[]
   dropdownStatusContent?: ReactNode
+  optionsBottomContent?: ReactNode
   open: boolean
   setOpen: (open: boolean) => void
   loading: boolean
@@ -38,6 +39,7 @@ export function DropdownUI<T>({
   loading,
   open,
   setOpen,
+  optionsBottomContent,
 }: Props<T>) {
   if (disabled) {
     searchable = false
@@ -177,6 +179,7 @@ export function DropdownUI<T>({
           dropdownPosition={dropdownPosition}
           wrapperRef={wrapperRef}
           dropdownStatusContent={dropdownStatusContent}
+          optionsBottomContent={optionsBottomContent}
         />,
         dropdownRoot,
       )}

--- a/src/components/atoms/internal/dropdown/dropdown.types.ts
+++ b/src/components/atoms/internal/dropdown/dropdown.types.ts
@@ -13,4 +13,5 @@ export type BaseDropdownProps<T> = {
   className?: string
   disabled?: boolean
   emptyContent?: ReactNode
+  optionsBottomContent?: ReactNode
 }

--- a/src/showcase/AsyncDropdownInputShowcase.tsx
+++ b/src/showcase/AsyncDropdownInputShowcase.tsx
@@ -113,6 +113,24 @@ export function AsyncDropdownInputShowcase({ error, placeholder, customEmptyCont
           emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
         />
       </div>
+
+      <div>
+        <div className="jui-text-base jui-font-semibold jui-mb-1">
+          Content underneath Options
+        </div>
+        <AsyncDropdownInput
+          placeholder={placeholder ?? "Type to search countries..."}
+          value={country}
+          onChange={setCountry}
+          optionToId={c => c.id}
+          optionToLabel={c => c.name}
+          error={error}
+          fetchOptions={fetchCountries}
+          debounceMs={300}
+          emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
+          optionsBottomContent={<div className="jui-bg-orange-500 jui-text-center jui-text-white jui-p-4">Custom content here</div>}
+        />
+      </div>
     </div>
   )
 }

--- a/src/showcase/DropdownInputShowcase.tsx
+++ b/src/showcase/DropdownInputShowcase.tsx
@@ -42,43 +42,76 @@ export function DropdownInputShowcase({ error, searchable, customEmptyContent }:
   return (
     <div className="jui-flex">
       <div className="jui-px-16 jui-py-8 jui-bg-white jui-space-y-2 jui-w-[24rem]">
-        <DropdownInput<Country>
-          placeholder="Country"
-          value={country}
-          options={countries}
-          optionToId={c => c.id}
-          optionToLabel={c => c.name}
-          onChange={setCountry}
-          error={error}
-          searchable={searchable}
-          emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
-        />
+        <div>
+          <div className="jui-text-base jui-font-semibold jui-mb-1">
+            Basic
+          </div>
+          <DropdownInput<Country>
+            placeholder="Country"
+            value={country}
+            options={countries}
+            optionToId={c => c.id}
+            optionToLabel={c => c.name}
+            onChange={setCountry}
+            error={error}
+            searchable={searchable}
+            emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
+          />
+        </div>
 
-        <DropdownInput<Country>
-          placeholder="Country"
-          value={country}
-          options={countries}
-          optionToId={c => c.id}
-          optionToLabel={c => c.name}
-          onChange={setCountry}
-          error={error}
-          loading={true}
-          searchable={searchable}
-          emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
-        />
+        <div>
+          <div className="jui-text-base jui-font-semibold jui-mb-1">
+            Loading
+          </div>
+          <DropdownInput<Country>
+            placeholder="Country"
+            value={country}
+            options={countries}
+            optionToId={c => c.id}
+            optionToLabel={c => c.name}
+            onChange={setCountry}
+            error={error}
+            loading={true}
+            searchable={searchable}
+            emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
+          />
+        </div>
 
-        <DropdownInput<Country>
-          placeholder="Country"
-          value={country}
-          options={countries}
-          optionToId={c => c.id}
-          optionToLabel={c => c.name}
-          onChange={setCountry}
-          error={error}
-          disabled
-          searchable={searchable}
-          emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
-        />
+        <div>
+          <div className="jui-text-base jui-font-semibold jui-mb-1">
+            Disabled
+          </div>
+          <DropdownInput<Country>
+            placeholder="Country"
+            value={country}
+            options={countries}
+            optionToId={c => c.id}
+            optionToLabel={c => c.name}
+            onChange={setCountry}
+            error={error}
+            disabled
+            searchable={searchable}
+            emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
+          />
+        </div>
+
+        <div>
+          <div className="jui-text-base jui-font-semibold jui-mb-1">
+            Content underneath Options
+          </div>
+          <DropdownInput<Country>
+            placeholder="Country"
+            value={country}
+            options={countries}
+            optionToId={c => c.id}
+            optionToLabel={c => c.name}
+            onChange={setCountry}
+            error={error}
+            searchable={searchable}
+            emptyContent={customEmptyContent ? <EmptyContent /> : undefined}
+            optionsBottomContent={<div className="jui-bg-orange-500 jui-text-center jui-text-white jui-p-4">Custom content here</div>}
+            />
+          </div>
       </div>
     </div>
   )


### PR DESCRIPTION
# Description
- added a new prop which allows to pass a react component to be displayed at the bottom of all options
- useful for scenarios in which we want to display an additional static option at the bottom of the list. On the likes of "Create new item" buttons or links.

# Usage
![image](https://github.com/user-attachments/assets/59db1888-3601-4125-8589-4b15f217b64f)
