### PR TITLE
JEL-1023: Fix npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,4 +18,4 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm build && pnpm build:types
       - run: pnpm config set //registry.npmjs.org/:_authToken ${{secrets.npm_token}}
-      - run: pnpm publish
+      - run: pnpm publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjelly/jelly-ui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "storybook dev -p 6006",


### PR DESCRIPTION
- Fixed this error

```
Run pnpm publish
 ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main".

If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".
Error: Process completed with exit code 1.
````