### PR TITLE
JEL-1479 Keep pills as one-line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjelly/jelly-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "storybook dev -p 6006",

--- a/src/components/atoms/Pill.tsx
+++ b/src/components/atoms/Pill.tsx
@@ -1,6 +1,12 @@
 import { MouseEventHandler } from 'react'
 
-export type PillVariant = 'primary' | 'secondary' | 'success' | 'outlined' | 'ghost' | 'warning'
+export type PillVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'outlined'
+  | 'ghost'
+  | 'warning'
 
 type Props = {
   variant: PillVariant
@@ -10,7 +16,8 @@ type Props = {
 }
 
 export function Pill({ label, onClick, variant, className = '' }: Props) {
-  const baseClass = 'jui-h-[1.25rem] jui-px-[0.6875rem] jui-rounded-full jui-inline-flex jui-items-center jui-justify-center jui-border'
+  const baseClass =
+    'jui-h-[1.25rem] jui-px-[0.6875rem] jui-rounded-full jui-inline-flex jui-items-center jui-justify-center jui-border jui-whitespace-nowrap'
   const clickable = onClick ? 'jui-cursor-pointer' : ''
 
   const variantClasses: Record<PillVariant, string> = {


### PR DESCRIPTION
This PR is to prevent the following sort of line break when the text in the pill is long.

<img width="435" height="622" alt="image" src="https://github.com/user-attachments/assets/0acd49db-841e-462f-b316-aadaaec7e23c" />
