### PR TITLE
JEL-1725: Reusable Confetti Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jelly-org/jelly-ui",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "storybook dev -p 6006",

--- a/src/components/organisms/modals/ConfettiModal.tsx
+++ b/src/components/organisms/modals/ConfettiModal.tsx
@@ -1,94 +1,52 @@
-import { useEffect, useState } from 'react'
-import Confetti from 'react-confetti'
-
 import { Modal } from '../../atoms/Modal'
 import { Typography } from '../../atoms/Typography'
 import { Button } from '../../atoms/Button'
 import imageSrc from '../../../assets/trophy.png'
+import { launchConfetti } from './ConfettiModal/launchConfetti'
 
 type Props = {
   open: boolean
   onClose: () => void
+  headingText?: string
+  captionText?: string
+  buttonText?: string
 }
 
-export function ConfettiModal({ open, onClose }: Props) {
-  const [numberOfPieces, setNumberOfPieces] = useState(200)
-  const [showConfetti, setShowConfetti] = useState(false)
-  const [windowDimensions, setWindowDimensions] = useState({
-    width: window.innerWidth,
-    height: window.innerHeight,
-  });
-
-  useEffect(() => {
-    function handleResize() {
-      setWindowDimensions({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    }
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  useEffect(() => {
-    let timeout: NodeJS.Timeout
-
-    if (showConfetti) {
-      timeout = setInterval(() => {
-        if (numberOfPieces <= 0) {
-          clearInterval(timeout)
-          setNumberOfPieces(0)
-        } else {
-          setNumberOfPieces(numberOfPieces - 25)
-        }
-      }, 500)
-    }
-
-    return () => clearInterval(timeout)
-  }, [showConfetti, numberOfPieces])
-
+export function ConfettiModal({
+  open,
+  onClose,
+  headingText = '',
+  captionText = '',
+  buttonText = 'done',
+}: Props) {
   function handleButtonClick() {
-    setNumberOfPieces(250)
-    setShowConfetti(true)
+    launchConfetti()
     onClose()
-    setTimeout(() => setShowConfetti(false), 7500)
   }
 
   return (
-    <>
-      {showConfetti && (
-        <div className="jui-fixed jui-z-20 jui-w-screen jui-h-screen jui-top-0 jui-left-0 jui-pointer-events-none">
-          <Confetti
-            numberOfPieces={numberOfPieces}
-            width={windowDimensions.width}
-            height={windowDimensions.height}
-          />
-        </div>
-      )}
+    <Modal open={open} onClose={onClose}>
+      <div className="jui-space-y-8">
+        <div className="jui-flex jui-flex-col jui-items-center jui-w-full">
+          <img src={imageSrc} alt="Trophy" className="jui-w-52" />
 
-      <Modal open={open} onClose={onClose}>
-        <div className="jui-space-y-8">
-          <div className="jui-flex jui-flex-col jui-items-center jui-w-full">
-            <img src={imageSrc} alt="Trophy" className="jui-w-52"/>
+          <div className="jui-text-center jui-space-y-2">
+            <Typography style="h6" className="jui-text-primary-900">
+              {headingText}
+            </Typography>
 
-            <div className="jui-text-center jui-space-y-2">
-              <Typography style="h6" className="jui-text-primary-900">You rock!</Typography>
-
-              <Typography style="caption" className="jui-text-primary-800">
-                You’ve completed onboarding with flying colours. Here’s your
-                Jelly trophy!
-              </Typography>
-            </div>
+            <Typography style="caption" className="jui-text-primary-800">
+              {captionText}
+            </Typography>
           </div>
-
-          <Button
-            onClick={handleButtonClick}
-            className="jui-w-full"
-            label="Where's the party?"
-          />
         </div>
-      </Modal>
-    </>
+
+        <Button
+          onClick={handleButtonClick}
+          className="jui-w-full"
+          label={buttonText}
+        />
+      </div>
+    </Modal>
   )
 }

--- a/src/components/organisms/modals/ConfettiModal/ConfettiOverlay/index.tsx
+++ b/src/components/organisms/modals/ConfettiModal/ConfettiOverlay/index.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+import Confetti from 'react-confetti'
+
+import type { ConfettiOverlayProps } from './types'
+
+const decrementAmount = 25
+const decrementIntervalMs = 500
+
+export function ConfettiOverlay({
+  durationMs,
+  initialPieces,
+  onComplete,
+}: ConfettiOverlayProps) {
+  const [numberOfPieces, setNumberOfPieces] = useState(initialPieces)
+  const [windowDimensions, setWindowDimensions] = useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  })
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      })
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNumberOfPieces((pieces) =>
+        pieces <= decrementAmount ? 0 : pieces - decrementAmount,
+      )
+    }, decrementIntervalMs)
+
+    const timeout = window.setTimeout(onComplete, durationMs)
+
+    return () => {
+      window.clearInterval(interval)
+      window.clearTimeout(timeout)
+    }
+  }, [durationMs, onComplete])
+
+  return (
+    <div className="jui-fixed jui-z-20 jui-w-screen jui-h-screen jui-top-0 jui-left-0 jui-pointer-events-none">
+      <Confetti
+        numberOfPieces={numberOfPieces}
+        width={windowDimensions.width}
+        height={windowDimensions.height}
+      />
+    </div>
+  )
+}

--- a/src/components/organisms/modals/ConfettiModal/ConfettiOverlay/types.ts
+++ b/src/components/organisms/modals/ConfettiModal/ConfettiOverlay/types.ts
@@ -1,0 +1,5 @@
+export type ConfettiOverlayProps = {
+  durationMs: number
+  initialPieces: number
+  onComplete: () => void
+}

--- a/src/components/organisms/modals/ConfettiModal/launchConfetti/index.tsx
+++ b/src/components/organisms/modals/ConfettiModal/launchConfetti/index.tsx
@@ -1,0 +1,25 @@
+import { createRoot } from 'react-dom/client'
+
+import { ConfettiOverlay } from '../ConfettiOverlay'
+import type { LaunchConfettiParams } from './types'
+
+export function launchConfetti({
+  durationMs = 7500,
+  initialPieces = 250,
+}: LaunchConfettiParams = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const root = createRoot(container)
+
+  root.render(
+    <ConfettiOverlay
+      durationMs={durationMs}
+      initialPieces={initialPieces}
+      onComplete={() => {
+        root.unmount()
+        container.remove()
+      }}
+    />,
+  )
+}

--- a/src/components/organisms/modals/ConfettiModal/launchConfetti/types.ts
+++ b/src/components/organisms/modals/ConfettiModal/launchConfetti/types.ts
@@ -1,0 +1,4 @@
+export type LaunchConfettiParams = {
+  durationMs?: number
+  initialPieces?: number
+}

--- a/src/showcase/KitchenSetupShowcase.tsx
+++ b/src/showcase/KitchenSetupShowcase.tsx
@@ -15,7 +15,11 @@ export function KitchenSetupShowcase() {
   const [steps, setSteps] = useState<Step[]>([
     { id: '1', text: 'Add team members', completed: false },
     { id: '2', text: 'Upload 6 invoice photos', completed: false },
-    { id: '3', text: 'Automate invoice direct from 1 supplier', completed: false },
+    {
+      id: '3',
+      text: 'Automate invoice direct from 1 supplier',
+      completed: false,
+    },
     { id: '4', text: 'Check big price changes', completed: false },
     { id: '5', text: 'Get the flash report', completed: false },
     { id: '6', text: 'Cost your cookbook', completed: false },
@@ -38,7 +42,7 @@ export function KitchenSetupShowcase() {
     setSteps(newSteps)
 
     // Trigger confetti
-    if (steps.filter(s => s.completed).length === steps.length) {
+    if (steps.filter((s) => s.completed).length === steps.length) {
       setShowModal(true)
     }
   }
@@ -50,12 +54,15 @@ export function KitchenSetupShowcase() {
           <ConfettiModal
             open={showModal}
             onClose={() => setShowModal(false)}
+            headingText="You rock!"
+            captionText="You’ve completed onboarding with flying colours. Here’s your Jelly trophy!"
+            buttonText="Where's the party?"
           />
 
           <KitchenSetup<Step>
             steps={steps}
             onClick={completeStep}
-            getStepKey={step => step.id}
+            getStepKey={(step) => step.id}
           />
         </div>
       </div>

--- a/src/stories/organisms/Modal.stories.tsx
+++ b/src/stories/organisms/Modal.stories.tsx
@@ -21,14 +21,14 @@ export default meta
 type Story<T> = StoryObj<{ component: typeof ModalShowcase<T> }>
 
 type ModalStory<
-  T extends JSXElementConstructor<any> | keyof IntrinsicElements
+  T extends JSXElementConstructor<any> | keyof IntrinsicElements,
 > = Story<Omit<ComponentProps<T>, 'open' | 'onClose'>>
 
 export const TestModalStory: ModalStory<typeof TestModal> = {
   name: 'Test Modal',
   args: {
     component: TestModal,
-    props: { ctaClicked: () => (void 0) },
+    props: { ctaClicked: () => void 0 },
   },
 }
 
@@ -36,7 +36,7 @@ export const JellySupportModalStory: ModalStory<typeof JellySupportModal> = {
   name: 'Jelly Support Modal',
   args: {
     component: JellySupportModal,
-    props: { ctaClicked: () => (void 0) },
+    props: { ctaClicked: () => void 0 },
   },
 }
 
@@ -44,7 +44,12 @@ export const ConfettiModalStory: ModalStory<typeof ConfettiModal> = {
   name: 'Confetti Modal',
   args: {
     component: ConfettiModal,
-    props: {},
+    props: {
+      headingText: 'You rock!',
+      captionText:
+        'You’ve completed onboarding with flying colours. Here’s your Jelly trophy!',
+      buttonText: "Where's the party?",
+    },
   },
 }
 


### PR DESCRIPTION
# Before
- all content was hardcoded inside ConfettiModal

# After
- content of the modal can be passed on from props -> making it reusable in various contexts
- modified previous places of usage in kitchen app to pass the content
- modified ConfettiModal to allow rendering of confetti even after component gets unmounted
  - it was either this, either making the parent component artificially extend it's lifecycle so it can wait for confetti to complete. Assuming this modal will be used in many other places in the future, it made more sense to avoid extra code in all places of usage by keeping it inside the confetti modal (at the cost of having a slightly more complex modal in jelly ui)